### PR TITLE
Allowing baking of database.php config file in BakingPlate 1.3

### DIFF
--- a/vendors/shells/plate.php
+++ b/vendors/shells/plate.php
@@ -76,7 +76,7 @@ class PlateShell extends Shell {
 		$this->out(passthru('git init'));
 		$this->all();
 		
-		$this->DbConfig->path = $working . DS . $this->params['app'] . DS . 'config' . DS;
+		$this->DbConfig->path = $working . DS . 'config' . DS;
 		if (!config('database')) {
 			$this->out(__("\nYour database configuration was not found. Take a moment to create one.", true));
 			$this->args = null;


### PR DESCRIPTION
Just removed part of the path so that it doesn't try to create the file in `localhost/app/app/config` but in `localhost/app/config`.
